### PR TITLE
Fix return of falsy values on exists method at  FileCache, MemcachedCache and MemcacheCache providers

### DIFF
--- a/src/Moust/Silex/Cache/MemcacheCache.php
+++ b/src/Moust/Silex/Cache/MemcacheCache.php
@@ -86,7 +86,13 @@ class MemcacheCache extends AbstractCache
      */
     public function exists($key)
     {
-        return !!$this->_memcache->get($key);
+        // $flags stays untouched if $key was not found on the server,
+        // this way we can determine if bool(false) was stored
+        $flags = false;
+
+        $this->_memcache->get($key, $flags);
+
+        return $flags !== false;
     }
 
     /**

--- a/src/Moust/Silex/Cache/MemcachedCache.php
+++ b/src/Moust/Silex/Cache/MemcachedCache.php
@@ -87,7 +87,9 @@ class MemcachedCache extends AbstractCache
      */
     public function exists($key)
     {
-        return !!$this->_memcached->get($key);
+        $this->_memcached->get($key);
+
+        return $this->getMemcached()->getResultCode() !== \Memcached::RES_NOTFOUND;
     }
 
     /**

--- a/src/Moust/Silex/Cache/MemcachedCache.php
+++ b/src/Moust/Silex/Cache/MemcachedCache.php
@@ -89,7 +89,7 @@ class MemcachedCache extends AbstractCache
     {
         $this->_memcached->get($key);
 
-        return $this->getMemcached()->getResultCode() !== \Memcached::RES_NOTFOUND;
+        return $this->getMemcached()->getResultCode() !== Memcached::RES_NOTFOUND;
     }
 
     /**

--- a/tests/Cache/AbstractCacheTest.php
+++ b/tests/Cache/AbstractCacheTest.php
@@ -78,7 +78,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse( $cache->exists('empty') );
 
-        $cache->store('empty', []);
+        $cache->store('empty', array());
 
         $this->assertTrue( $cache->exists('empty') );
 

--- a/tests/Cache/AbstractCacheTest.php
+++ b/tests/Cache/AbstractCacheTest.php
@@ -69,6 +69,38 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue( $cache->exists('foo') );
     }
 
+    public function testCacheExistsOfFalsyValues()
+    {
+        $cache = $this->instanciateCache();
+
+        // Empty array is a valid cache value
+        $cache->delete('empty');
+
+        $this->assertFalse( $cache->exists('empty') );
+
+        $cache->store('empty', []);
+
+        $this->assertTrue( $cache->exists('empty') );
+
+        // null is a valid cache value
+        $cache->delete('null');
+
+        $this->assertFalse( $cache->exists('null') );
+
+        $cache->store('null', null);
+
+        $this->assertTrue( $cache->exists('null') );
+
+        // false is a valid cache value
+        $cache->delete('false');
+
+        $this->assertFalse( $cache->exists('false') );
+
+        $cache->store('false', false);
+
+        $this->assertTrue( $cache->exists('false') );
+    }
+
 
     /**
      * Tests clear cache


### PR DESCRIPTION
Currently on the FileCache and MemcachedCache and MemcacheCache  providers, to verify if a cache item exists it does:

```
return !!$this->fetch($key);
```

This means that for any true value (numbers other than zero, non-empty strings and arrays, etc.) we will get the boolean value `true` but for any false value (0, 0.0, null, empty strings or empty arrays) we will get boolean value `false` which from my point of view are valid cached values.